### PR TITLE
Renovated Preact template

### DIFF
--- a/templates/preact/.babelrc
+++ b/templates/preact/.babelrc
@@ -1,5 +1,13 @@
 {
-    "presets": ["babel-preset-preact"],
+    "plugins": [
+        [
+            "@babel/plugin-transform-react-jsx",
+            {
+                "runtime": "automatic",
+                "importSource": "preact"
+            }
+        ]
+    ],
     "env": {
         "development": {
             "plugins": ["react-refresh/babel"]

--- a/templates/preact/package.json
+++ b/templates/preact/package.json
@@ -5,20 +5,20 @@
         "build": "npm run clean && rollup -c --environment NODE_ENV:production"
     },
     "dependencies": {
-        "preact": "^10.4.1"
+        "preact": "^10.5.13"
     },
     "devDependencies": {
-        "@babel/core": "^7.5.5",
-        "@prefresh/nollup": "^0.5.0",
-        "babel-preset-preact": "^2.0.0",
-        "nollup": "^0.15.0",
-        "react-refresh": "^0.8.2",
-        "rollup": "^2.38.5",
-        "rollup-plugin-babel": "^4.3.3",
-        "rollup-plugin-hot-css": "^0.2.1",
-        "rollup-plugin-node-resolve": "^5.2.0",
-        "rollup-plugin-static-files": "0.0.1",
-        "rollup-plugin-terser": "^5.1.1",
-        "shx": "^0.3.2"
+        "@babel/core": "^7.14.0",
+        "@babel/plugin-transform-react-jsx": "^7.13.12",
+        "@prefresh/nollup": "^3.0.1",
+        "@rollup/plugin-babel": "^5.3.0",
+        "@rollup/plugin-node-resolve": "^13.0.0",
+        "nollup": "^0.16.4",
+        "react-refresh": "^0.10.0",
+        "rollup": "^2.47.0",
+        "rollup-plugin-hot-css": "^0.5.0",
+        "rollup-plugin-static-files": "^0.2.0",
+        "rollup-plugin-terser": "^7.0.2",
+        "shx": "^0.3.3"
     }
 }

--- a/templates/preact/rollup.config.js
+++ b/templates/preact/rollup.config.js
@@ -1,5 +1,5 @@
-import node_resolve from 'rollup-plugin-node-resolve';
-import babel from 'rollup-plugin-babel';
+import node_resolve from '@rollup/plugin-node-resolve';
+import babel from '@rollup/plugin-babel';
 import hotcss from 'rollup-plugin-hot-css';
 import static_files from 'rollup-plugin-static-files';
 import { terser } from 'rollup-plugin-terser';
@@ -19,7 +19,8 @@ let config = {
             file: 'styles.css'
         }),
         babel({
-            exclude: 'node_modules/**'
+            exclude: 'node_modules/**',
+            babelHelpers: 'bundled',
         }),
         node_resolve(),
         process.env.NODE_ENV === 'development' && prefresh()

--- a/templates/preact/src/main.js
+++ b/templates/preact/src/main.js
@@ -1,7 +1,5 @@
-import { render, h } from 'preact';
+import { render } from 'preact';
 import App from './App';
-
-window.h = h;
 
 let root = document.querySelector('#app');
 document.body.appendChild(root);


### PR DESCRIPTION
* fully configured JSX transformation (fixes #1)
* all deprecated Rollup plugins replaced with current packages
* updated all package versions

Use of Babel "automatic" JSX runtime allowed to drop the hack with
assigning `preact.h` and `preact.Fragment` on `window` object (these are
now injected automatically by Babel).